### PR TITLE
Inspect remote images

### DIFF
--- a/api/client/inspect.go
+++ b/api/client/inspect.go
@@ -5,11 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 	"text/template"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/parsers"
+	"github.com/docker/docker/registry"
 )
 
 // CmdInspect displays low-level information on one or more containers or images.
@@ -19,6 +23,8 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 	cmd := cli.Subcmd("inspect", []string{"CONTAINER|IMAGE [CONTAINER|IMAGE...]"}, "Return low-level information on a container or image", true)
 	tmplStr := cmd.String([]string{"f", "#format", "-format"}, "", "Format the output using the given go template")
 	inspectType := cmd.String([]string{"-type"}, "", "Return JSON for specified type, (e.g image or container)")
+	remote := cmd.Bool([]string{"r", "-remote"}, false, "Inspect remote images")
+
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)
@@ -37,13 +43,23 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 	if *inspectType != "" && *inspectType != "container" && *inspectType != "image" {
 		return fmt.Errorf("%q is not a valid value for --type", *inspectType)
 	}
+	if *inspectType == "container" && *remote {
+		return fmt.Errorf("conflicting options: --remote && --type=container")
+	}
+	if *remote {
+		*inspectType = "image"
+	}
 
 	indented := new(bytes.Buffer)
 	indented.WriteString("[\n")
 	status := 0
-	isImage := false
 
 	for _, name := range cmd.Args() {
+		var (
+			err     error
+			isImage = false
+			resp    = &serverResponse{}
+		)
 
 		if *inspectType == "" || *inspectType == "container" {
 			obj, _, err = readBody(cli.call("GET", "/containers/"+name+"/json", nil, nil))
@@ -59,11 +75,31 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 		}
 
 		if obj == nil && (*inspectType == "" || *inspectType == "image") {
-			obj, _, err = readBody(cli.call("GET", "/images/"+name+"/json", nil, nil))
+			if *remote {
+				var repoInfo *registry.RepositoryInfo
+				taglessRemote, _ := parsers.ParseRepositoryTag(name)
+				// Resolve the Repository name from fqn to RepositoryInfo
+				repoInfo, err = registry.ParseRepositoryInfo(taglessRemote)
+				if err != nil {
+					return err
+				}
+				v := url.Values{}
+				v.Set("remote", "1")
+				body, statusCode, respErr := cli.clientRequestAttemptLogin("GET", "/images/"+name+"/json?"+v.Encode(), nil, nil, repoInfo.Index, "inspect")
+				if respErr == nil {
+					resp = &serverResponse{body: body, statusCode: statusCode}
+				} else {
+					err = respErr
+				}
+			} else {
+				resp, err = cli.call("GET", "/images/"+name+"/json", nil, nil)
+			}
+			obj, _, err = readBody(resp, err)
+
 			isImage = true
 			if err != nil {
-				if strings.Contains(err.Error(), "No such") {
-					if *inspectType == "" {
+				if strings.Contains(err.Error(), "No such") || strings.Contains(strings.ToLower(err.Error()), "not found") {
+					if *inspectType == "" || !*remote {
 						fmt.Fprintf(cli.err, "Error: No such image or container: %s\n", name)
 					} else {
 						fmt.Fprintf(cli.err, "Error: No such image: %s\n", name)
@@ -74,11 +110,34 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 				status = 1
 				continue
 			}
-
 		}
 
 		if tmpl == nil {
-			if err := json.Indent(indented, obj, "", "    "); err != nil {
+			if *remote {
+				rdr := bytes.NewReader(obj)
+				dec := json.NewDecoder(rdr)
+
+				remoteImage := types.RemoteImageInspect{}
+				if err := dec.Decode(&remoteImage); err != nil {
+					fmt.Fprintf(cli.err, "%s\n", err)
+				} else {
+					ref := name
+					if remoteImage.Tag != "" {
+						ref += ":" + remoteImage.Tag
+					}
+					if remoteImage.Digest != "" {
+						ref += "@" + remoteImage.Digest
+					}
+					logrus.Debugf("Inspecting image %s", ref)
+					encoded, err := json.Marshal(&remoteImage.ImageInspectBase)
+					if err != nil {
+						fmt.Fprintf(cli.err, "%s\n", err)
+					} else {
+						obj = encoded
+					}
+				}
+			}
+			if err = json.Indent(indented, obj, "", "    "); err != nil {
 				fmt.Fprintf(cli.err, "%s\n", err)
 				status = 1
 				continue
@@ -88,13 +147,32 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 			dec := json.NewDecoder(rdr)
 
 			if isImage {
-				inspPtr := types.ImageInspect{}
-				if err := dec.Decode(&inspPtr); err != nil {
-					fmt.Fprintf(cli.err, "%s\n", err)
-					status = 1
-					continue
+				if *remote {
+					remoteImage := types.RemoteImageInspect{}
+					if err := dec.Decode(&remoteImage); err != nil {
+						fmt.Fprintf(cli.err, "%s\n", err)
+						status = 1
+						continue
+					}
+					ref := name
+					if remoteImage.Tag != "" {
+						ref += ":" + remoteImage.Tag
+					}
+					if remoteImage.Digest != "" {
+						ref += "@" + remoteImage.Digest
+					}
+					logrus.Debugf("Inspecting image %s", ref)
+					err = tmpl.Execute(cli.out, &remoteImage.ImageInspectBase)
+				} else {
+					inspPtr := types.ImageInspect{}
+					if err := dec.Decode(&inspPtr); err != nil {
+						fmt.Fprintf(cli.err, "%s\n", err)
+						status = 1
+						continue
+					}
+					err = tmpl.Execute(cli.out, inspPtr)
 				}
-				if err := tmpl.Execute(cli.out, inspPtr); err != nil {
+				if err != nil {
 					rdr.Seek(0, 0)
 					var raw interface{}
 					if err := dec.Decode(&raw); err != nil {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -80,8 +80,7 @@ type GraphDriverData struct {
 	Data map[string]string
 }
 
-// GET "/images/{name:.*}/json"
-type ImageInspect struct {
+type ImageInspectBase struct {
 	Id              string
 	Parent          string
 	Comment         string
@@ -94,8 +93,21 @@ type ImageInspect struct {
 	Architecture    string
 	Os              string
 	Size            int64
-	VirtualSize     int64
-	GraphDriver     GraphDriverData
+}
+
+// GET "/images/{name:.*}/json"
+type ImageInspect struct {
+	ImageInspectBase
+	VirtualSize int64
+	GraphDriver GraphDriverData
+}
+
+// GET "/images/{name:.*}/json?remote=1"
+type RemoteImageInspect struct {
+	ImageInspectBase
+	Registry string
+	Digest   string
+	Tag      string
 }
 
 // GET  "/containers/json"

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -205,6 +205,7 @@ complete -c docker -f -n '__fish_docker_no_subcommand' -a info -d 'Display syste
 complete -c docker -f -n '__fish_docker_no_subcommand' -a inspect -d 'Return low-level information on a container or image'
 complete -c docker -A -f -n '__fish_seen_subcommand_from inspect' -s f -l format -d 'Format the output using the given go template.'
 complete -c docker -A -f -n '__fish_seen_subcommand_from inspect' -l help -d 'Print usage'
+complete -c docker -A -f -n '__fish_seen_subcommand_from inspect' -s r -l remote -d 'Inspect remote images'
 complete -c docker -A -f -n '__fish_seen_subcommand_from inspect' -a '(__fish_print_docker_images)' -d "Image"
 complete -c docker -A -f -n '__fish_seen_subcommand_from inspect' -a '(__fish_print_docker_containers all)' -d "Container"
 

--- a/graph/service.go
+++ b/graph/service.go
@@ -4,10 +4,23 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/pkg/transport"
+	"github.com/docker/docker/registry"
+	"github.com/docker/docker/utils"
 )
+
+// LookupRemoteConfig allows you to pass transport-related data to LookupRemote
+// function.
+type LookupRemoteConfig struct {
+	MetaHeaders map[string][]string
+	AuthConfig  *cliconfig.AuthConfig
+}
 
 func (s *TagStore) LookupRaw(name string) ([]byte, error) {
 	image, err := s.LookupImage(name)
@@ -31,29 +44,271 @@ func (s *TagStore) Lookup(name string) (*types.ImageInspect, error) {
 	}
 
 	imageInspect := &types.ImageInspect{
-		Id:              image.ID,
-		Parent:          image.Parent,
-		Comment:         image.Comment,
-		Created:         image.Created,
-		Container:       image.Container,
-		ContainerConfig: &image.ContainerConfig,
-		DockerVersion:   image.DockerVersion,
-		Author:          image.Author,
-		Config:          image.Config,
-		Architecture:    image.Architecture,
-		Os:              image.OS,
-		Size:            image.Size,
-		VirtualSize:     s.graph.GetParentsSize(image, 0) + image.Size,
+		types.ImageInspectBase{
+			Id:              image.ID,
+			Parent:          image.Parent,
+			Comment:         image.Comment,
+			Created:         image.Created,
+			Container:       image.Container,
+			ContainerConfig: &image.ContainerConfig,
+			DockerVersion:   image.DockerVersion,
+			Author:          image.Author,
+			Config:          image.Config,
+			Architecture:    image.Architecture,
+			Os:              image.OS,
+			Size:            image.Size,
+		},
+		s.graph.GetParentsSize(image, 0) + image.Size,
+		types.GraphDriverData{
+			Name: s.graph.driver.String(),
+		},
 	}
-
-	imageInspect.GraphDriver.Name = s.graph.driver.String()
 
 	graphDriverData, err := s.graph.driver.GetMetadata(image.ID)
 	if err != nil {
 		return nil, err
 	}
 	imageInspect.GraphDriver.Data = graphDriverData
+
 	return imageInspect, nil
+}
+
+func (s *TagStore) LookupRemote(name, tag string, config *LookupRemoteConfig) (*types.RemoteImageInspect, error) {
+	var (
+		img  *Image
+		dgst digest.Digest
+	)
+
+	// Resolve the Repository name from fqn to RepositoryInfo
+	repoInfo, err := s.registryService.ResolveRepository(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateRepoName(repoInfo.LocalName); err != nil {
+		return nil, err
+	}
+
+	endpoint, err := repoInfo.GetEndpoint(config.MetaHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	tr := transport.NewTransport(
+		registry.NewTransport(registry.ReceiveTimeout, endpoint.IsSecure),
+		registry.DockerHeaders(config.MetaHeaders)...,
+	)
+	client := registry.HTTPClient(tr)
+	r, err := registry.NewSession(client, config.AuthConfig, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	logName := repoInfo.CanonicalName
+	if tag != "" {
+		logName = utils.ImageReference(logName, tag)
+	}
+
+	if len(repoInfo.Index.Mirrors) == 0 && (repoInfo.Index.Official || endpoint.Version == registry.APIVersion2) {
+		if repoInfo.Official {
+			s.trustService.UpdateBase()
+		}
+
+		logrus.Debugf("pulling v2 repository manifest named %q", logName)
+		if img, tag, dgst, err = s.pullJSONFromV2Registry(r, repoInfo, tag); err == nil {
+			s.eventsService.Log("inspect", logName, "")
+		} else if err != registry.ErrDoesNotExist && err != ErrV2RegistryUnavailable {
+			logrus.Errorf("Error from V2 registry: %s", err)
+		}
+	}
+
+	if img == nil {
+		logrus.Debugf("pulling v1 repository manifest named %q", logName)
+		if img, tag, err = s.pullJSONFromRegistry(r, repoInfo, tag); err != nil {
+			return nil, err
+		}
+	}
+
+	imageInspect := &types.RemoteImageInspect{
+		types.ImageInspectBase{
+			Id:              img.ID,
+			Parent:          img.Parent,
+			Comment:         img.Comment,
+			Created:         img.Created,
+			Container:       img.Container,
+			ContainerConfig: &img.ContainerConfig,
+			DockerVersion:   img.DockerVersion,
+			Author:          img.Author,
+			Config:          img.Config,
+			Architecture:    img.Architecture,
+			Os:              img.OS,
+			Size:            img.Size,
+		},
+		repoInfo.Index.Name,
+		dgst.String(),
+		tag,
+	}
+
+	return imageInspect, nil
+}
+
+func (s *TagStore) pullJSONFromV2Registry(r *registry.Session, repoInfo *registry.RepositoryInfo, tag string) (*Image, string, digest.Digest, error) {
+	endpoint, err := r.V2RegistryEndpoint(repoInfo.Index)
+	if err != nil {
+		if repoInfo.Index.Official {
+			logrus.Debugf("Unable to pull from V2 registry, falling back to v1: %s", err)
+			return nil, tag, "", ErrV2RegistryUnavailable
+		}
+		return nil, tag, "", fmt.Errorf("error getting registry endpoint: %s", err)
+	}
+	auth, err := r.GetV2Authorization(endpoint, repoInfo.RemoteName, true)
+	if err != nil {
+		return nil, tag, "", fmt.Errorf("error getting authorization: %s", err)
+	}
+	if tag == "" {
+		logrus.Debugf("Retrieving V2 tag list")
+		tags, err := r.GetV2RemoteTags(endpoint, repoInfo.RemoteName, auth)
+		if err != nil {
+			return nil, tag, "", fmt.Errorf("Failed to get remote tags: %v", err)
+		}
+		for _, t := range tags {
+			if t == DEFAULTTAG {
+				tag = DEFAULTTAG
+			}
+		}
+		if tag == "" && len(tags) > 0 {
+			tag = tags[0]
+		}
+		if tag == "" {
+			return nil, "", "", fmt.Errorf("No tags available for repository %s", repoInfo.CanonicalName)
+		}
+	}
+	img, dgst, err := s.pullV2ImageJSON(r, endpoint, repoInfo, tag, auth)
+	if err == nil && dgst.String() == tag {
+		// Don't show digest as a tag
+		tag = ""
+	}
+	return img, tag, dgst, err
+}
+
+func (s *TagStore) pullV2ImageJSON(r *registry.Session, endpoint *registry.Endpoint, repoInfo *registry.RepositoryInfo, tag string, auth *registry.RequestAuthorization) (*Image, digest.Digest, error) {
+	var (
+		err error
+		img *Image
+	)
+	logrus.Debugf("Pulling tag from V2 registry: %q", tag)
+
+	remoteDigest, manifestBytes, err := r.GetV2ImageManifest(endpoint, repoInfo.RemoteName, tag, auth)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// loadManifest ensures that the manifest payload has the expected digest
+	// if the tag is a digest reference.
+	_, manifest, verified, err := s.loadManifest(manifestBytes, tag, remoteDigest)
+	if err != nil {
+		return nil, "", fmt.Errorf("error verifying manifest: %s", err)
+	}
+
+	if verified {
+		logrus.Infof("Image manifest for %s has been verified", utils.ImageReference(repoInfo.CanonicalName, tag))
+	}
+
+	if len(manifest.FSLayers) < 1 {
+		return nil, "", fmt.Errorf("No layer in obtained manifest!")
+	}
+	imgJSON := []byte(manifest.History[0].V1Compatibility)
+	img, err = NewImgJSON(imgJSON)
+	return img, remoteDigest, err
+}
+
+func (s *TagStore) pullJSONFromRegistry(r *registry.Session, repoInfo *registry.RepositoryInfo, askedTag string) (*Image, string, error) {
+	repoData, err := r.GetRepositoryData(repoInfo.RemoteName)
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP code: 404") {
+			return nil, "", fmt.Errorf("Error: image %s not found", utils.ImageReference(repoInfo.RemoteName, askedTag))
+		}
+		// Unexpected HTTP error
+		return nil, "", err
+	}
+
+	logrus.Debugf("Retrieving the tag list")
+	tagsList, err := r.GetRemoteTags(repoData.Endpoints, repoInfo.RemoteName)
+	if err != nil {
+		logrus.Errorf("Unable to get remote tags: %s", err)
+		return nil, "", err
+	}
+	if len(tagsList) < 1 {
+		return nil, "", fmt.Errorf("No tags available for remote repository %s", repoInfo.CanonicalName)
+	}
+
+	for tag, id := range tagsList {
+		repoData.ImgList[id] = &registry.ImgData{
+			ID:       id,
+			Tag:      tag,
+			Checksum: "",
+		}
+	}
+
+	// If no tag has been specified, choose `latest` if it exists
+	if askedTag == "" {
+		if _, exists := tagsList[DEFAULTTAG]; exists {
+			askedTag = DEFAULTTAG
+		}
+	}
+	if askedTag == "" {
+		// fallback to any tag in the repository
+		for tag := range tagsList {
+			askedTag = tag
+			break
+		}
+	}
+
+	id, exists := tagsList[askedTag]
+	if !exists {
+		return nil, "", fmt.Errorf("Tag %s not found in repository %s", askedTag, repoInfo.CanonicalName)
+	}
+	img := repoData.ImgList[id]
+
+	var pulledImg *Image
+	for _, ep := range repoInfo.Index.Mirrors {
+		if pulledImg, err = s.pullImageJSON(r, img.ID, ep, repoData.Tokens); err != nil {
+			// Don't report errors when pulling from mirrors.
+			logrus.Debugf("Error pulling image json of %s:%s, mirror: %s, %s", repoInfo.CanonicalName, img.Tag, ep, err)
+			continue
+		}
+		break
+	}
+	if pulledImg == nil {
+		for _, ep := range repoData.Endpoints {
+			if pulledImg, err = s.pullImageJSON(r, img.ID, ep, repoData.Tokens); err != nil {
+				// It's not ideal that only the last error is returned, it would be better to concatenate the errors.
+				logrus.Infof("Error pulling image json of %s:%s, endpoint: %s, %v", repoInfo.CanonicalName, img.Tag, ep, err)
+				continue
+			}
+			break
+		}
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("Error pulling image (%s) from %s, %v", img.Tag, repoInfo.CanonicalName, err)
+	}
+	if pulledImg == nil {
+		return nil, "", fmt.Errorf("No such image %s:%s", repoInfo.CanonicalName, askedTag)
+	}
+
+	return pulledImg, askedTag, nil
+}
+
+func (s *TagStore) pullImageJSON(r *registry.Session, imgID, endpoint string, token []string) (*Image, error) {
+	imgJSON, _, err := r.GetRemoteImageJSON(imgID, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	img, err := NewImgJSON(imgJSON)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse json: %s", err)
+	}
+	return img, nil
 }
 
 // ImageTarLayer return the tarLayer of the image

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/exec"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -263,5 +265,156 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
 	_, err = strconv.ParseUint(deviceSize, 10, 64)
 	if err != nil {
 		c.Fatalf("failed to inspect DeviceSize of the image: %s, %v", deviceSize, err)
+	}
+}
+
+func compareInspectValues(c *check.C, name string, local, remote interface{}) {
+	additionalLocalAttributes := map[string]struct{}{
+		"GraphDriver": {},
+		"VirtualSize": {},
+	}
+
+	isRootObject := len(name) <= 4
+
+	if reflect.TypeOf(local) != reflect.TypeOf(remote) {
+		c.Errorf("types don't match for %q: %T != %T", name, local, remote)
+		return
+	}
+	switch local.(type) {
+	case bool:
+		lVal := local.(bool)
+		rVal := remote.(bool)
+		if lVal != rVal {
+			c.Errorf("local value differs from remote for %q: %t != %t", name, lVal, rVal)
+		}
+	case float64:
+		lVal := local.(float64)
+		rVal := remote.(float64)
+		if lVal != rVal {
+			c.Errorf("local value differs from remote for %q: %f != %f", name, lVal, rVal)
+		}
+	case string:
+		lVal := local.(string)
+		rVal := remote.(string)
+		if lVal != rVal {
+			c.Errorf("local value differs from remote for %q: %q != %q", name, lVal, rVal)
+		}
+	// JSON array
+	case []interface{}:
+		lVal := local.([]interface{})
+		rVal := remote.([]interface{})
+		if len(lVal) != len(rVal) {
+			c.Errorf("array length differs between local and remote for %q: %d != %d", name, len(lVal), len(rVal))
+		}
+		for i := 0; i < len(lVal) && i < len(rVal); i++ {
+			compareInspectValues(c, fmt.Sprintf("%s[%d]", name, i), lVal[i], rVal[i])
+		}
+	// JSON object
+	case map[string]interface{}:
+		lMap := local.(map[string]interface{})
+		rMap := remote.(map[string]interface{})
+		if isRootObject && len(lMap) != len(rMap)+len(additionalLocalAttributes) {
+			c.Errorf("got unexpected number of root object's attributes from remote inpect %q: %d != %d", name, len(lMap), len(rMap)+len(additionalLocalAttributes))
+		} else if !isRootObject && len(lMap) != len(rMap) {
+			c.Errorf("map length differs between local and remote for %q: %d != %d", name, len(lMap), len(rMap))
+		}
+		for key, lVal := range lMap {
+			itemName := fmt.Sprintf("%s.%s", name, key)
+			rVal, ok := rMap[key]
+			if ok {
+				compareInspectValues(c, itemName, lVal, rVal)
+			} else if _, exists := additionalLocalAttributes[key]; !isRootObject || !exists {
+				c.Errorf("attribute %q present in local but not in remote object", itemName)
+			}
+		}
+		for key := range rMap {
+			if _, ok := lMap[key]; !ok {
+				c.Errorf("attribute \"%s.%s\" present in remote but not in local object", name, key)
+			}
+		}
+	case nil:
+		if local != remote {
+			c.Errorf("local value differs from remote for %q: %v (%T) != %v (%T)", name, local, local, remote, remote)
+		}
+	default:
+		c.Fatalf("got unexpected type (%T) for %q", local, name)
+	}
+}
+
+func (s *DockerRegistrySuite) TestInspectRemoteRepository(c *check.C) {
+	var (
+		localValue  []interface{}
+		remoteValue []interface{}
+	)
+	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
+	// tag the image to upload it to the private registry
+	tagCmd := exec.Command(dockerBinary, "tag", "busybox", repoName)
+	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
+		c.Fatalf("image tagging failed: %s, %v", out, err)
+	}
+
+	inspectCmd := exec.Command(dockerBinary, "inspect", repoName)
+	localOut, _, err := runCommandWithOutput(inspectCmd)
+	if err != nil {
+		c.Fatalf("failed to inspect local busybox image : %s, %v", localOut, err)
+	}
+	pushCmd := exec.Command(dockerBinary, "push", repoName)
+	if out, _, err := runCommandWithOutput(pushCmd); err != nil {
+		c.Fatalf("pushing the image to the private registry has failed: %s, %v", out, err)
+	}
+	inspectCmd = exec.Command(dockerBinary, "inspect", "-r", repoName)
+	remoteOut, _, err := runCommandWithOutput(inspectCmd)
+	if err != nil {
+		c.Fatalf("failed to inspect remote busybox image : %s, %v", remoteOut, err)
+	}
+
+	if err = json.Unmarshal([]byte(localOut), &localValue); err != nil {
+		c.Fatalf("failed to parse result for local busybox image: %v", err)
+	}
+
+	if err = json.Unmarshal([]byte(remoteOut), &remoteValue); err != nil {
+		c.Fatalf("failed to parse result for local busybox image: %v", err)
+	}
+
+	compareInspectValues(c, "a", localValue, remoteValue)
+
+	deleteImages(repoName)
+
+	// local inspect shall fail now
+	inspectCmd = exec.Command(dockerBinary, "inspect", repoName)
+	localOut, _, err = runCommandWithOutput(inspectCmd)
+	if err == nil {
+		c.Fatalf("inspect on removed local images should have failed: %s", localOut)
+	}
+
+	// remote inspect shall still succeed
+	inspectCmd = exec.Command(dockerBinary, "inspect", "-r", repoName)
+	remoteOut2, _, err := runCommandWithOutput(inspectCmd)
+	if err != nil {
+		c.Fatalf("failed to inspect remote busybox image : %s, %v", remoteOut2, err)
+	}
+
+	if remoteOut != remoteOut2 {
+		c.Fatalf("remote inspect should produce identical output as before:\nfirst run: %s\n\nsecond run: %s", remoteOut, remoteOut2)
+	}
+}
+
+func (s *DockerRegistrySuite) TestInspectNonExistentRepository(c *check.C) {
+	repoName := fmt.Sprintf("%s/foo/non-existent", privateRegistryURL)
+
+	inspectCmd := exec.Command(dockerBinary, "inspect", repoName)
+	out, _, err := runCommandWithOutput(inspectCmd)
+	if err == nil {
+		c.Error("inspecting non-existent image should have failed", out)
+	} else if !strings.Contains(strings.ToLower(out), "no such image or container") {
+		c.Errorf("got unexpected error message: %v", out)
+	}
+
+	inspectCmd = exec.Command(dockerBinary, "inspect", "-r", repoName)
+	out, _, err = runCommandWithOutput(inspectCmd)
+	if err == nil {
+		c.Error("inspecting non-existent image should have failed", out)
+	} else if !strings.Contains(strings.ToLower(out), "no such image:") {
+		c.Errorf("got unexpected error message: %v", out)
 	}
 }

--- a/man/docker-inspect.1.md
+++ b/man/docker-inspect.1.md
@@ -8,6 +8,7 @@ docker-inspect - Return low-level information on a container or image
 **docker inspect**
 [**--help**]
 [**-f**|**--format**[=*FORMAT*]]
+[**-r**|**--remote**[=*false*]]
 [**--type**=*container*|*image*]
 CONTAINER|IMAGE [CONTAINER|IMAGE...]
 
@@ -24,6 +25,14 @@ each result.
 
 **-f**, **--format**=""
     Format the output using the given go template.
+
+**-r**, **--remote**=*true*|*false*
+    Inspect remote images.
+
+    Image name can be suffixed with [:TAG]. If short name is given, all
+additional registries will be searched until a match is found. The default is
+*false*. To see image's digest string and its source registry, pass **-D**
+option to Docker client. Implies **--type=image**.
 
 **--type**=*container*|*image*
     Return JSON for specified type, permissible values are "image" or "container"


### PR DESCRIPTION
Added new flag to `docker inspect` command:

```
$ docker inspect --remote <imageName>[:<tag>]...
```

Which inspects remote images. If a short name is given, all additional registries will be queried until a match is found. Additional `[:TAG]` suffix may further specify desired `<image>`.

This allows for remote inspection without downloading image layers.
